### PR TITLE
fix: add compatibility with IntelliJ IDEA 2026.1 (261.*)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-04-09
+
+### Changed
+
+- Added compatibility with newer IntelliJ versions (261.*).
+
 ## [0.1.7] - 2025-12-08
 
 ### Changed
@@ -61,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an issue where the Color Scheme was not being loaded with the Theme.
 
-[Unreleased]: https://github.com/vikthorvergara/vesperoso/compare/v0.1.7...HEAD
+[Unreleased]: https://github.com/vikthorvergara/vesperoso/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/vikthorvergara/vesperoso/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/vikthorvergara/vesperoso/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/vikthorvergara/vesperoso/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/vikthorvergara/vesperoso/compare/v0.1.4...v0.1.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ pluginGroup = com.github.vikthorvergara.vesperoso
 pluginName = vesperoso
 pluginRepositoryUrl = https://github.com/vikthorvergara/vesperoso
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.7
+pluginVersion = 0.1.8
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 232
-pluginUntilBuild = 253.*
+pluginUntilBuild = 261.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = II
-platformVersion = 2025.3
+platformVersion = 2026.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
## Summary
- Bumps `pluginUntilBuild` from `253.*` to `261.*` and `platformVersion` from `2025.3` to `2026.1` so the plugin loads in IntelliJ IDEA 2026.1, which previously rejected it with `Incompatible: requires IDE build 253.* or earlier`.
- Bumps `pluginVersion` to `0.1.8` and adds a `0.1.8` changelog entry.
- `pluginSinceBuild` stays at `232`, so older IDEs are still supported.

IntelliJ IDEA 2026.1 was released on March 25, 2026 as build `261.*`. See [JetBrains release post](https://blog.jetbrains.com/idea/2026/03/intellij-idea-2026-1/) and the [build number ranges reference](https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html).

## Test plan
- [ ] `./gradlew verifyPlugin` succeeds against 2026.1
- [ ] `./gradlew runIde` launches 2026.1 with the theme applied
- [ ] Plugin still resolves on an older supported IDE (e.g. 2023.2 / build 232.*)

https://claude.ai/code/session_01RRCDbRAp96TBsqtniMRKbL